### PR TITLE
-Add filtering by activity type; activities not matching the desired …

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ There are multiple ways to configure values, the precedence order is:
 |[PELOTON] Email|-email EMAIL|P2G_PELOTON_EMAIL|Peloton email address|
 |[PELOTON] Password|-password PASWORD|P2G_PELOTON_PASS| Peloton password|
 |[PELOTON] NumActivities|-num #|P2G_NUM|Batch size of activities to grab at one time|
+|[PELOTON] WorkoutTypes|-workout_types &lt;types&gt;|P2G_WORKOUT_TYPES|If set, take only Peloton workouts of the specified types (see below)
 |[GARMIN] UploadEnabled|-garmin_enable_upload true/false|P2G_GARMIN_ENABLE_UPLOAD|Automatically upload to Garmin Connect|
 |[GARMIN] Email|-garmin_email EMAIL|P2G_GARMIN_EMAIL|Garmin Email|
 |[GARMIN] Password|-garmin_password PASSWORD|P2G_GARMIN_PASS|Garmin Password|
@@ -106,7 +107,6 @@ There are multiple ways to configure values, the precedence order is:
 |[DEBUG] PauseOnFinish|-pause_on_finish true/false|P2G_PAUSE_ON_FINISH|Do not automatically close the application on completion.|
 |[LOGGER] LogFile|-log|P2G_LOG|Log file path|
 |[LOGGER] LogLevel|-loglevel|P2G_LOG_LEVEL|DEBUG, INFO, ERROR|
-
 ### Command Line Arguments
 
 Usage:  
@@ -121,6 +121,19 @@ Examples:
         * `peloton-to-garmin.py -num 10`  
   * To pass your email and passowrd:  
         * `peloton-to-garmin.py -email you@email.com -password mypassword`  
+
+### Restricting Peloton workout types
+By default, all Peloton workouts are processed.  However, you can optionally filter for only specific types of workouts, such as only cycling and running; all other workouts will be skipped.
+
+Specify a comma-separated list of workout types you want to allow.  The values may be one or more of the following: cardio, circuit, cycling, meditation, running, strength, stretching, walking, yoga
+
+Example:
+`-workout_types cardio,cycling,running,strength`
+
+Use cases:
+* You take a wide variety of Peloton classes, including meditation and yoga, but you only want to upload cycling classes.
+* You want to avoid double-counting activities you already track directly on a Garmin device, such as outdoor running workouts.
+
 
 ## Supported Python/OS
 

--- a/config.ini
+++ b/config.ini
@@ -5,6 +5,10 @@ LogLevel = INFO
 [PELOTON]
 Email = pelotonEmail@example.com
 Password = pelotonPassword
+# If defined, only process Peloton activities matching the specified types.  Omit or leave blank to
+# allow all types.  When using filters, the number of activities processed may be lower than -num.
+# Known types: cardio, circuit, running, cycling, walking, strength, stretching, meditation, yoga
+#WorkoutTypes = cycling, strength 
 
 [GARMIN]
 UploadEnabled = false

--- a/lib/configuration.py
+++ b/lib/configuration.py
@@ -32,6 +32,7 @@ class Configuration:
         args.add_argument("-garmin_enable_upload",help="True will try to upload activities to Garmin", dest="garmin_enable_upload", type=str, default=os.environ.get('P2G_GARMIN_ENABLE_UPLOAD'))
         args.add_argument("-path",help="Path to output directory",dest="output_dir",type=str, default=os.environ.get('P2G_PATH'))
         args.add_argument("-num",help="Number of activities to download",dest="num_to_download",type=int, default=os.environ.get('P2G_NUM'))
+        args.add_argument("-workout_types",help="Process specified activity types only", dest="workout_types", type=str, default=os.environ.get('P2G_WORKOUT_TYPES'))
         args.add_argument("-log",help="Log file name",dest="log_file",type=str, default=os.environ.get('P2G_LOG'))
         args.add_argument("-loglevel",help="[DEBUG, INFO, ERROR]",dest="log_level",type=str, default=os.environ.get('P2G_LOG_LEVEL'))
         args.add_argument("-pause_on_finish",help="Do not automatically close the application on completion.", dest="pause_on_finish",type=str, default=os.environ.get('P2G_PAUSE_ON_FINISH'))
@@ -128,6 +129,17 @@ class Configuration:
             self.peloton_password = argResults.password
         else: 
             self.peloton_password = config.ConfigSectionMap("PELOTON").get('password')
+
+        # If set, the opt-in list of activities to include.  Peloton activity types not included
+        # in this list will be ignored (not saved, not uploaded).  Omit or leave blank to allow all.
+        if argResults.workout_types is not None:
+            pelotonWorkoutTypes = argResults.workout_types
+        else:
+            pelotonWorkoutTypes = config.ConfigSectionMap("PELOTON").get("workouttypes")
+        if pelotonWorkoutTypes is not None :
+            self.pelotonWorkoutTypes = [ item.strip().lower() for item in pelotonWorkoutTypes.split(",") ]
+        else:
+            self.pelotonWorkoutTypes = []
 
     def loadGarminConfig(self, argResults):
         if argResults.garmin_email is not None:

--- a/lib/tcx_builder.py
+++ b/lib/tcx_builder.py
@@ -59,7 +59,14 @@ def getInstructor(workout):
         if workout["ride"]["instructor"] is not None:
             return unidecode(" with " + workout["ride"]["instructor"]["name"])
     return ""
-    
+
+def getRideTitle(workout):
+    if workout["workout_type"] == "class":
+        instructor = getInstructor(workout)
+        rideTitle = unidecode(workout["ride"]["title"].replace("/","-").replace(":","-"))
+        return "{0}{1}".format(rideTitle, instructor)
+    return ""
+
 def getDistanceMeters(workoutSamples):
     try:
         distanceSlug = next((x for x in workoutSamples["summaries"] if x["slug"] == "distance"), None)
@@ -382,3 +389,29 @@ def workoutSamplesToTCX(workout, workoutSummary, workoutSamples, outputDir):
     outputDir = outputDir.replace("\"", "")
     tree.write(os.path.join(outputDir,filename), xml_declaration=True, encoding="UTF-8", method="xml")
     return title, filename, granular_garmin_activity_type
+
+
+
+def GetWorkoutSummary( workout ) :
+    # Extracts a few fields from the workout summary record for convenient access.
+    summary = {}
+
+    try:
+        summary[ "workout_type" ] = workout.get("fitness_discipline","")
+    except:
+        pass
+
+    try:
+        summary[ "workout_started" ] = ""
+        temp = workout["start_time"]
+        activity_started = datetime.fromtimestamp( temp )
+        summary[ "workout_started" ] = activity_started.strftime("%c")
+    except:
+        pass
+
+    try:
+        summary[ "workout_title" ] = getRideTitle(workout)
+    except:
+        pass
+
+    return summary

--- a/peloton-to-garmin.py
+++ b/peloton-to-garmin.py
@@ -48,6 +48,16 @@ class PelotonToGarmin:
 
             workout = pelotonClient.getWorkoutById(workoutId)
 
+            # Print basic summary about the workout here, because if we filter out the activity type
+            # we won't otherwise see the activity.
+            workoutSummary = tcx_builder.GetWorkoutSummary( workout )
+            logger.info( "{workoutId} : {title} ({type}) at {timestamp}".format(workoutId = workoutId, title = workoutSummary['workout_title'], type = workoutSummary['workout_type'], timestamp = workoutSummary['workout_started'] ) )
+
+            # Skip the unwanted activities before downloading the rest of the data.
+            if config.pelotonWorkoutTypes and not workoutSummary["workout_type"] in config.pelotonWorkoutTypes :
+                logger.info( "Workout type: {type} - skipping".format(type = workoutSummary['workout_type']) )
+                continue
+
             logger.info("Get workout samples")
             workoutSamples = pelotonClient.getWorkoutSamplesById(workoutId)
 


### PR DESCRIPTION
…… (#82)

* -Add filtering by activity type; activities not matching the desired types will not be processed.
e.g. the command line arg "-workout_types cycling,strength" will process those activities, but skip over any running, stretching, yoga, etc.
-Output to the log basic info about each workout (title, type, timestamp)

* Replaced f-string for compatibility with python 3.5

* Updated README.md, removed unnecessary import